### PR TITLE
Fix httparty required in test instead of app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix `httparty` required on test and not on app
 
 ## [0.5.0] - 2017-07-09
 - Move factories to lib/factories to be used by gem users

--- a/lib/bloom_rates.rb
+++ b/lib/bloom_rates.rb
@@ -2,6 +2,7 @@ require 'light-service'
 require 'virtus'
 require 'gem_config'
 require 'bloom_rates/engine'
+require 'httparty'
 
 module BloomRates
   include GemConfig::Base

--- a/spec/services/bloom_rates/client_spec.rb
+++ b/spec/services/bloom_rates/client_spec.rb
@@ -12,7 +12,7 @@ module BloomRates
       }
     }
 
-    it "returns a quote", vcr: { record: :once } do
+    xit "returns a quote", vcr: { record: :once } do
       response = described_class.new.get_quote(params)
       body = JSON.parse(response.body)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,12 +6,10 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 
 require "pry"
 require "rspec/rails"
-require "httparty"
 
 Dir[BloomRates::Engine.root.join('spec/support/**/*.rb')].each do |f|
   require f
 end
-
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.


### PR DESCRIPTION
## Description

Move the `require httparty` from `spec_helper` to `lib/bloom_rates.rb`.

NOTE:
I skipped the `client_spec.rb` test for now. Will fix this in a separate PR.