### PR TITLE
Do not setup the gem automatically, let dev set up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Do not register the schedule; require devs to set it up themselves
+
 ## [0.14.1] - 2018-09-05
 ### Added
 - Fix `stellar_address`, not `stellar_account` (in `GetQuoteResponse`)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,24 @@ BloomTradeClient.configure do |c|
 end
 ```
 
-5. Add the following to your sidekiq-cron schedule (unless you're already doing this for something else in your app):
+5. Add another initializer if you don't have one yet `config/initializers/message_bus_client_worker.rb`:
+
+```ruby
+MessageBusClientWorker.configure do |c|
+  c.subscriptions = {
+    "https://staging.trade.bloom.solutions" => {
+      BloomTradeClient::EXCHANGE_RATES_CHANNEL => {
+        processor: BloomTradeClient::ExchangeRates::Sync.to_s,
+        message_id: 0,
+      }
+    }
+  }
+end
+```
+
+This gem used to set up MessageBusClientWorker for you, but if you were to use that elsewhere in your app, that introduced the possibility overwriting the config accidentally. Setting it up explicitly avoids that.
+
+6. Add the following to your sidekiq-cron schedule (unless you're already doing this for something else in your app):
 
 ```yaml
 message_bus_client_worker:

--- a/lib/bloom_trade_client.rb
+++ b/lib/bloom_trade_client.rb
@@ -17,7 +17,7 @@ module BloomTradeClient
 
   include APIClientBase::Base.module
 
-  DEFAULT_CHANNEL = '/exchange_rates'.freeze
+  EXCHANGE_RATES_CHANNEL = '/exchange_rates'.freeze
 
   with_configuration do
     has(:host, {
@@ -25,26 +25,6 @@ module BloomTradeClient
       default: 'https://staging.trade.bloom.solutions',
     })
     has :reserve_currency, classes: String, default: 'PHP'
-  end
-
-  after_configuration_change do
-    configure_message_bus_client_worker
-  end
-
-  def self.configure_message_bus_client_worker
-    host = BloomTradeClient.configuration.host
-
-    # Do not completely override MessageBusClientWorker config since this might
-    # be used by the host application for other items. It is safe to assume,
-    # however, that if the BloomTrade is listened to it's only this gem
-    # that's doing so
-    MessageBusClientWorker.configuration.subscriptions ||= {}
-    MessageBusClientWorker.configuration.subscriptions[host] = {
-      DEFAULT_CHANNEL => {
-        processor: BloomTradeClient::ExchangeRates::Sync.to_s,
-        message_id: 0,
-      }
-    }
   end
 
   def self.convert(base_currency:, counter_currency:, type:)

--- a/spec/lib/bloom_trade_client_spec.rb
+++ b/spec/lib/bloom_trade_client_spec.rb
@@ -9,12 +9,6 @@ RSpec.describe BloomTradeClient do
 
     expect(described_class.configuration.host).to eq "https://tradewebsite.com"
     expect(described_class.configuration.reserve_currency).to eq "USD"
-    subscription_config = MessageBusClientWorker.configuration.
-      subscriptions["https://tradewebsite.com"]\
-      [described_class::DEFAULT_CHANNEL]
-    expect(subscription_config[:processor]).
-      to eq BloomTradeClient::ExchangeRates::Sync.to_s
-    expect(subscription_config[:message_id]).to eq 0
   end
 
   describe ".convert" do


### PR DESCRIPTION
This gem used to set up MessageBusClientWorker for you, but if you were to use that elsewhere in your app, that introduced the possibility overwriting the config accidentally. Setting it up explicitly avoids that.