### PR TITLE
Minor changes to `ConversionResult`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.16.0] - 2018-11-09
+## [0.16.2] - 2018-11-23
+### Added
+- Install `virtus-matchers` gem
+- Unit test for `BloomTradeClient::ConversionResult`
+
+### Changed
+- Convert `BloomTradeClient::ConversionResult` to a Virtus model
+
+## [0.16.1] - 2018-11-09
 ### Fixed
 - Fix not returning `BloomTradeClient::ConversionResult` on reverse rates
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ PATH
       rails (~> 5.2)
       typhoeus (~> 1.3)
       virtus (~> 1.0)
+      virtus-matchers
 
 GEM
   remote: https://rubygems.org/
@@ -224,6 +225,8 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    virtus-matchers (0.4.0)
+      virtus (~> 1.0.0)
     webmock (3.4.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)

--- a/app/models/bloom_trade_client/conversion_result.rb
+++ b/app/models/bloom_trade_client/conversion_result.rb
@@ -1,10 +1,10 @@
 module BloomTradeClient
   class ConversionResult
-    attr_reader :rate, :expires_at
 
-    def initialize(rate, expires_at="")
-      @rate = rate
-      @expires_at = expires_at
-    end
+    include Virtus.model
+
+    attribute :rate, Float
+    attribute :expires_at, Integer, default: 0
+
   end
 end

--- a/app/services/bloom_trade_client/exchange_rates/convert.rb
+++ b/app/services/bloom_trade_client/exchange_rates/convert.rb
@@ -14,12 +14,12 @@ module BloomTradeClient
         origin_rate = direct_rate(type, base_currency, reserve_currency)
         destination_rate = direct_rate(type, reserve_currency, counter_currency)
         reverse_rate = origin_rate.rate * destination_rate.rate if origin_rate && destination_rate
-        return ConversionResult.new(reverse_rate) if reverse_rate
+        return ConversionResult.new(rate: reverse_rate) if reverse_rate
 
         Rails.logger.error(
           "Unable to calculate rate #{base_currency}#{counter_currency}"
         )
-        return ConversionResult.new(0.0)
+        return ConversionResult.new(rate: 0.0)
       end
 
       private
@@ -27,7 +27,7 @@ module BloomTradeClient
       def self.direct_rate(type, base_currency, counter_currency)
         return nil unless %w(buy sell mid).include? type
 
-        return ConversionResult.new(1.0) if base_currency == counter_currency
+        return ConversionResult.new(rate: 1.0) if base_currency == counter_currency
 
         exchange_rate = ExchangeRate.find_by(
           base_currency: base_currency,
@@ -36,8 +36,8 @@ module BloomTradeClient
 
         if exchange_rate
           return ConversionResult.new(
-            exchange_rate.send(type.to_sym),
-            exchange_rate.expires_at
+            rate: exchange_rate.send(type.to_sym),
+            expires_at: exchange_rate.expires_at
           )
         end
 
@@ -48,8 +48,8 @@ module BloomTradeClient
 
         if reversed_rate
           return ConversionResult.new(
-            1.0 / reversed_rate.send(type.to_sym),
-            reversed_rate.expires_at
+            rate: 1.0 / reversed_rate.send(type.to_sym),
+            expires_at: reversed_rate.expires_at
           )
         end
       end

--- a/bloom_trade_client.gemspec
+++ b/bloom_trade_client.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency "message_bus_client_worker", ">= 0.2.0"
   s.add_dependency "rails", "~> 5.2"
   s.add_dependency "virtus", "~> 1.0"
+  s.add_dependency "virtus-matchers"
   s.add_dependency "addressable", "~> 2.5"
 
   s.add_development_dependency "sqlite3", "~> 1.3"

--- a/spec/models/bloom_trade_client/conversion_result_spec.rb
+++ b/spec/models/bloom_trade_client/conversion_result_spec.rb
@@ -1,0 +1,8 @@
+module BloomTradeClient
+  RSpec.describe ConversionResult, type: :virtus do
+
+    it { is_expected.to have_attribute(:rate, Float) }
+    it { is_expected.to have_attribute(:expires_at, Integer).with_default(0) }
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "pry"
 require "rspec/rails"
 require "webmock/rspec"
+require "virtus/matchers/rspec"
 
 Dir[BloomTradeClient::Engine.root.join('spec/support/**/*.rb')].each do |f|
   require f


### PR DESCRIPTION
## Changes
- Add unit test to `ConversionResult`
- It now uses `virtus` gem to add attribute types
- Default `expires_at` to 0.
- Updated Changelog

I'll push a separate PR to bump this gem version for release.