### PR TITLE
Developers can easily get errors from a response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Add `.errors` to `BaseResponse`
+
 ## [0.16.2] - 2018-11-23
 ### Added
 - Install `virtus-matchers` gem

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you're new to sidekiq-cron, see the [docs](https://github.com/ondrejbartas/si
 
 ## API
 
-Requesting a Quote from Bloom Trade
+#### Requesting a Quote from Bloom Trade
 
 ```ruby
 client = BloomTradeClient::Client.new(token: "your-api-token-here")
@@ -93,7 +93,14 @@ response = client.get_quote(
 response.quoted_amount # this is where you'll get the BTC amount
 ```
 
-Updating a Quote from Bloom Trade
+if there are any errors, you can inspect using:
+
+```
+response.success?
+response.errors
+```
+
+#### Updating a Quote from Bloom Trade
 
 ```ruby
 response = client.update_quote(

--- a/lib/bloom_trade_client/responses/base_response.rb
+++ b/lib/bloom_trade_client/responses/base_response.rb
@@ -3,6 +3,7 @@ module BloomTradeClient
     include APIClientBase::Response.module
 
     attribute :body, String, lazy: true, default: :default_body
+    attribute :errors, Hash, lazy: true, default: :default_errors
 
     private
 
@@ -10,6 +11,15 @@ module BloomTradeClient
       JSON.parse(raw_response.body).with_indifferent_access
     end
 
+    def default_errors
+      errors = if body.is_a? Hash
+                 body[:errors]
+               else
+                 JSON.parse(body)["errors"]
+               end
+
+      errors.with_indifferent_access.deep_symbolize_keys if errors.present?
+    end
   end
 end
 

--- a/lib/bloom_trade_client/responses/base_response.rb
+++ b/lib/bloom_trade_client/responses/base_response.rb
@@ -12,12 +12,7 @@ module BloomTradeClient
     end
 
     def default_errors
-      errors = if body.is_a? Hash
-                 body[:errors]
-               else
-                 JSON.parse(body)["errors"]
-               end
-
+      errors = body[:errors]
       errors.with_indifferent_access.deep_symbolize_keys if errors.present?
     end
   end

--- a/spec/fixtures/errors.json
+++ b/spec/fixtures/errors.json
@@ -1,0 +1,9 @@
+{
+  "errors":{
+    "description": "Hello",
+    "metadata": {
+      "max": "5.0"
+    }
+  }
+}
+

--- a/spec/lib/bloom_trade_client/responses/base_response_spec.rb
+++ b/spec/lib/bloom_trade_client/responses/base_response_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+module BloomTradeClient
+  RSpec.describe BaseResponse do
+
+    describe "#errors" do
+      let(:response) do
+        described_class.new(body: File.read(FIXTURES_DIR.join("errors.json")))
+      end
+
+      it "returns errors" do
+        expect(response.errors[:description]).to eq "Hello"
+        expect(response.errors[:metadata]).to eq({ max: "5.0" })
+      end
+    end
+
+  end
+end

--- a/spec/lib/bloom_trade_client/responses/base_response_spec.rb
+++ b/spec/lib/bloom_trade_client/responses/base_response_spec.rb
@@ -4,9 +4,12 @@ module BloomTradeClient
   RSpec.describe BaseResponse do
 
     describe "#errors" do
-      let(:response) do
-        described_class.new(body: File.read(FIXTURES_DIR.join("errors.json")))
+      let(:raw_response) do
+        Typhoeus::Response.new(
+          body: File.read(FIXTURES_DIR.join("errors.json"))
+        )
       end
+      let(:response) { described_class.new(raw_response: raw_response) }
 
       it "returns errors" do
         expect(response.errors[:description]).to eq "Hello"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,8 +14,10 @@ Dir[BloomTradeClient::Engine.root.join('spec/support/**/*.rb')].each do |f|
 end
 
 SPEC_DIR = Pathname.new(File.dirname(__FILE__))
-CONFIG = YAML.load_file(SPEC_DIR.join("config.yml")).
-  with_indifferent_access
+CONFIG = YAML.load_file(SPEC_DIR.join("config.yml"))
+  .with_indifferent_access
+
+FIXTURES_DIR = SPEC_DIR.join("fixtures")
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.


### PR DESCRIPTION
Bloom Trade returns a `errors` key in the response body if there are errors in the `GET` or `PUT` request.

This PR adds a `.errors` to any `...Response` object returned from the client.