### PR TITLE
Return global direct/reverse rate if JWT is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2018-02-20
+### Changed
+- Refactor `BloomTradeClient::ExchangeRates::Convert` class.
+- Return global direct/reverse rate if no ExchangeRate is found given a
+`jwt_hash`.
+
 ## [0.18.0] - 2018-02-12
 ### Added
 - New `jwt_hash` column for `ExchangeRate`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ PATH
       api_client_base (~> 1.0)
       light-service (= 0.11.0)
       loofah (>= 2.2.3)
-      message_bus_client_worker (~> 1.0)
+      message_bus_client_worker (~> 1.1)
       rails (~> 5.2)
       sidekiq (>= 5.1)
       typhoeus (~> 1.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bloom_trade_client-rails (0.18.0)
+    bloom_trade_client-rails (0.19.0)
       addressable (~> 2.5)
       api_client_base (~> 1.0)
       light-service (= 0.11.0)
@@ -115,7 +115,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    message_bus_client_worker (1.1.0)
+    message_bus_client_worker (1.1.1)
       activesupport
       addressable
       excon

--- a/app/services/bloom_trade_client/exchange_rates/convert.rb
+++ b/app/services/bloom_trade_client/exchange_rates/convert.rb
@@ -34,6 +34,13 @@ module BloomTradeClient
           jwt_hash: jwt_hash 
         }
 
+        if jwt_hash.present?
+          rate = direct_rate_for(type, opts) || reversed_rate_for(type, opts)
+          return rate if rate
+          global_opts = opts.merge(jwt_hash: nil)
+          return direct_rate_for(type, global_opts) || reversed_rate_for(type, global_opts)
+        end
+
         direct_rate_for(type, opts) || reversed_rate_for(type, opts)
       end
       private_class_method :calculate_rate

--- a/bloom_trade_client.gemspec
+++ b/bloom_trade_client.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency "api_client_base", "~> 1.0"
   s.add_dependency "light-service", "0.11.0"
   s.add_dependency "loofah", ">= 2.2.3"
-  s.add_dependency "message_bus_client_worker", "~> 1.0"
+  s.add_dependency "message_bus_client_worker", "~> 1.1"
   s.add_dependency "rails", "~> 5.2"
   s.add_dependency "sidekiq", ">= 5.1"
   s.add_dependency "typhoeus", "~> 1.3"

--- a/lib/bloom_trade_client/version.rb
+++ b/lib/bloom_trade_client/version.rb
@@ -1,3 +1,3 @@
 module BloomTradeClient
-  VERSION = "0.18.0"
+  VERSION = "0.19.0".freeze
 end

--- a/spec/services/bloom_trade_client/exchange_rates/convert_spec.rb
+++ b/spec/services/bloom_trade_client/exchange_rates/convert_spec.rb
@@ -169,20 +169,23 @@ module BloomTradeClient
           let(:jwt_hash) { Digest::SHA256.base64digest("my-jwt") }
 
           context "direct_rate exists" do
-            it "calculates using the direct rate" do
+            before do
               create(:bloom_trade_client_exchange_rate, {
                 base_currency: "PHP",
                 counter_currency: "USD",
                 mid: 50.0,
                 jwt_hash: nil,
               })
+
               create(:bloom_trade_client_exchange_rate, {
                 base_currency: "PHP",
                 counter_currency: "USD",
                 mid: 80.0,
                 jwt_hash: jwt_hash,
               })
+            end
 
+            it "calculates using the direct rate" do
               resulting_rate = described_class.(
                 base_currency: "PHP",
                 counter_currency: "USD",
@@ -193,7 +196,7 @@ module BloomTradeClient
           end
 
           context "reverse_rate exists" do
-            it "calculates using the reverse rate" do
+            before do
               create(:bloom_trade_client_exchange_rate, {
                 base_currency: "PHP",
                 counter_currency: "USD",
@@ -206,7 +209,9 @@ module BloomTradeClient
                 mid: 80.0,
                 jwt_hash: jwt_hash,
               })
+            end
 
+            it "calculates using the reverse rate" do
               resulting_rate = described_class.(
                 base_currency: "USD",
                 counter_currency: "PHP",

--- a/spec/services/bloom_trade_client/exchange_rates/convert_spec.rb
+++ b/spec/services/bloom_trade_client/exchange_rates/convert_spec.rb
@@ -17,13 +17,15 @@ module BloomTradeClient
         end
 
         context "direct_rate exists" do
-          it "calculates using the direct rate" do
+          before do
             create(:bloom_trade_client_exchange_rate, {
               base_currency: "PHP",
               counter_currency: "USD",
               mid: 50.0,
             })
+          end
 
+          it "calculates using the direct rate" do
             resulting_rate = described_class.(
               base_currency: "PHP",
               counter_currency: "USD",
@@ -34,26 +36,27 @@ module BloomTradeClient
         end
 
         context "reversed_rate exists" do
-          it "calculates by dividing with 1" do
+          before do
             create(:bloom_trade_client_exchange_rate, {
               base_currency: "PHP",
               counter_currency: "USD",
               mid: 50.0,
             })
+          end
 
+          it "calculates by dividing with 1" do
             resulting_rate = described_class.(
               base_currency: "PHP",
               counter_currency: "USD",
               jwt: nil
             )
-
             expect(resulting_rate).to be_a BloomTradeClient::ConversionResult
             expect(resulting_rate.rate).to eq 50
           end
         end
 
         context "currency_pair don't exist, use reserve_currency" do
-          it "calculates by using the reserve currency" do
+          before do
             create(:bloom_trade_client_exchange_rate, {
               base_currency: "PHP",
               counter_currency: "BTC",
@@ -64,7 +67,9 @@ module BloomTradeClient
               counter_currency: "KRW",
               mid: 20,
             })
+          end
 
+          it "calculates by using the reserve currency" do
             resulting_rate = described_class.(
               base_currency: "BTC",
               counter_currency: "KRW",
@@ -76,7 +81,7 @@ module BloomTradeClient
         end
 
         context "currency pair don't exist, unable to use reserve_currency" do
-          it "returns 0.0" do
+          before do
             create(:bloom_trade_client_exchange_rate, {
               base_currency: "PHP",
               counter_currency: "BTC",
@@ -87,7 +92,9 @@ module BloomTradeClient
               counter_currency: "KRW",
               mid: 20,
             })
+          end
 
+          it "returns 0.0" do
             resulting_rate = described_class.(
               base_currency: "BTC",
               counter_currency: "AED",
@@ -193,6 +200,15 @@ module BloomTradeClient
               )
               expect(resulting_rate.rate).to eq 80.0
             end
+
+            it "returns the global direct rate if none is found for that jwt_hash" do
+              resulting_rate = described_class.(
+                base_currency: "PHP",
+                counter_currency: "USD",
+                jwt: "a-non-existent-jwt",
+              )
+              expect(resulting_rate.rate).to eq 50.0
+            end
           end
 
           context "reverse_rate exists" do
@@ -218,6 +234,15 @@ module BloomTradeClient
                 jwt: "my-jwt",
               )
               expect(resulting_rate.rate).to eq (1/80.0)
+            end
+
+            it "returns the global reverse rate if none is found for that jwt_hash" do
+              resulting_rate = described_class.(
+                base_currency: "PHP",
+                counter_currency: "USD",
+                jwt: "a-non-existent-jwt",
+              )
+              expect(resulting_rate.rate).to eq 50.0
             end
           end
         end


### PR DESCRIPTION
### Description
Let's not return a default `ConversionResult` with **0.0** rate. It's better if we return the global rate for that currency pair instead.

