### PR TITLE
BloomTradeClient developer sees exception when rate is outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.18.0] - 2018-02-12
+## [1.0.0] - 2019-02-22
+### Changed
+- `BloomTradeClient::ExchangeRates::Convert` raises an error if rate has
+  expired.
+- Renamed method from `convert` to `convert!`.
+
+## [0.18.0] - 2019-02-12
 ### Added
 - New `jwt_hash` column for `ExchangeRate`
 - New `jwt_callback` config which accepts an Object that responds to 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    bloom_trade_client-rails (0.18.0)
+    bloom_trade_client-rails (1.0.0)
       addressable (~> 2.5)
       api_client_base (~> 1.0)
       light-service (= 0.11.0)
@@ -115,7 +115,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    message_bus_client_worker (1.1.0)
+    message_bus_client_worker (1.1.1)
       activesupport
       addressable
       excon

--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ This so that Bloom Trade can issue the corresponding base/counter currency (base
 to fulfill the quote.
 
 Checking the value of a currency to another e.g. 1 BTC for USD. You can choose
-from either `["buy", "sell", "mid"]`. Mid is the average value.
+from either `["buy", "sell", "mid"]`. Mid is the average value. If the rate has
+expired, this method will raise `BloomTradeClient::ExpiredRateError`.
 ```ruby
-result = BloomTradeClient.convert(
+result = BloomTradeClient.convert!(
   base_currency: "BTC", counter_currency: "USD", type: "buy"
 )
 ```

--- a/app/models/bloom_trade_client/exchange_rate.rb
+++ b/app/models/bloom_trade_client/exchange_rate.rb
@@ -1,4 +1,12 @@
 module BloomTradeClient
   class ExchangeRate < ApplicationRecord
+
+    def expired?
+      return true unless self.expires_at
+      expires_at_in_utc = Time.at(self.expires_at).utc
+
+      expires_at_in_utc < Time.now.utc
+    end
+
   end
 end

--- a/app/services/bloom_trade_client/exchange_rates/convert.rb
+++ b/app/services/bloom_trade_client/exchange_rates/convert.rb
@@ -38,6 +38,7 @@ module BloomTradeClient
         )
 
         if exchange_rate
+          raise BloomTradeClient::ExpiredRateError if exchange_rate.expired?
           return ConversionResult.new(
             rate: exchange_rate.send(type.to_sym),
             expires_at: exchange_rate.expires_at
@@ -51,6 +52,7 @@ module BloomTradeClient
         )
 
         if reversed_rate
+          raise BloomTradeClient::ExpiredRateError if reversed_rate.expired?
           return ConversionResult.new(
             rate: 1.0 / reversed_rate.send(type.to_sym),
             expires_at: reversed_rate.expires_at

--- a/lib/bloom_trade_client.rb
+++ b/lib/bloom_trade_client.rb
@@ -6,6 +6,7 @@ require 'virtus'
 
 require 'bloom_trade_client/engine'
 require 'bloom_trade_client/client'
+require 'bloom_trade_client/exceptions'
 require 'bloom_trade_client/requests/base_authenticated_request'
 require 'bloom_trade_client/requests/get_quote_request'
 require 'bloom_trade_client/requests/update_quote_request'

--- a/lib/bloom_trade_client.rb
+++ b/lib/bloom_trade_client.rb
@@ -30,7 +30,7 @@ module BloomTradeClient
     has :jwt_callback, classes: Object
   end
 
-  def self.convert(base_currency:, counter_currency:, type:, jwt: nil)
+  def self.convert!(base_currency:, counter_currency:, type:, jwt: nil)
     BloomTradeClient::ExchangeRates::Convert.(
       base_currency: base_currency,
       counter_currency: counter_currency,

--- a/lib/bloom_trade_client/exceptions.rb
+++ b/lib/bloom_trade_client/exceptions.rb
@@ -1,0 +1,3 @@
+module BloomTradeClient
+  ExpiredRateError = Class.new(StandardError)
+end

--- a/lib/bloom_trade_client/factories/bloom_trade_client_exchange_rate.rb
+++ b/lib/bloom_trade_client/factories/bloom_trade_client_exchange_rate.rb
@@ -1,3 +1,5 @@
 FactoryBot.define do
-  factory :bloom_trade_client_exchange_rate, class: "BloomTradeClient::ExchangeRate"
+  factory :bloom_trade_client_exchange_rate, class: "BloomTradeClient::ExchangeRate" do
+    expires_at { 2.days.from_now }
+  end
 end

--- a/lib/bloom_trade_client/version.rb
+++ b/lib/bloom_trade_client/version.rb
@@ -1,3 +1,3 @@
 module BloomTradeClient
-  VERSION = "0.18.0"
+  VERSION = "1.0.0".freeze
 end

--- a/spec/lib/bloom_trade_client_spec.rb
+++ b/spec/lib/bloom_trade_client_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe BloomTradeClient do
     expect(described_class.configuration.jwt_callback).to eq callback
   end
 
-  describe ".convert" do
+  describe ".convert!" do
     it "calls the BloomTradeClient::ExchangeRates::Convert#call" do
       expect(BloomTradeClient::ExchangeRates::Convert).to receive(:call)
 
-      BloomTradeClient.convert(
+      BloomTradeClient.convert!(
         base_currency: "BTC", 
         counter_currency: "PHP", 
         type: "buy",

--- a/spec/models/bloom_trade_client/exchange_rate_spec.rb
+++ b/spec/models/bloom_trade_client/exchange_rate_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+module BloomTradeClient
+  RSpec.describe ExchangeRate do
+
+    describe "#expired?" do
+      it "returns true if expires_at is nil" do
+        model = described_class.new(expires_at: nil)
+        expect(model).to be_expired
+      end
+
+      it "returns true if expires_at is past the current time" do
+        model = described_class.new(expires_at: 3.days.ago)
+        expect(model).to be_expired
+      end
+
+      it "returns false otherwise" do
+        model = described_class.new(expires_at: 3.days.from_now)
+        expect(model).not_to be_expired
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
### Description
If rate has expired, raise `BloomTradeClient::ExpiredRateError`.

### Pivotal Story
https://www.pivotaltracker.com/story/show/164067458