### PR TITLE
Response's body now returns the **unparsed** string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - `#get_order` to fetch order details
 
+### Changed
+- A response's body now returns the **unparsed** string. Use **parsed_body** instead
+
 ## [1.0.0] - 2019-02-22
 ### Changed
 - `BloomTradeClient::ExchangeRates::Convert` raises an error if rate has

--- a/app/responses/bloom_trade_client/base_response.rb
+++ b/app/responses/bloom_trade_client/base_response.rb
@@ -3,19 +3,22 @@ module BloomTradeClient
     include APIClientBase::Response.module
 
     attribute :body, String, lazy: true, default: :default_body
+    attribute :parsed_body, Object, lazy: true, default: :default_parsed_body
     attribute :errors, Hash, lazy: true, default: :default_errors
 
     private
 
     def default_body
-      JSON.parse(raw_response.body).with_indifferent_access
+      raw_response.body
+    end
+
+    def default_parsed_body
+      JSON.parse(body).with_indifferent_access
     end
 
     def default_errors
-      errors = body[:errors]
+      errors = parsed_body[:errors]
       errors.with_indifferent_access.deep_symbolize_keys if errors.present?
     end
   end
 end
-
-

--- a/app/responses/bloom_trade_client/get_order_response.rb
+++ b/app/responses/bloom_trade_client/get_order_response.rb
@@ -6,7 +6,7 @@ module BloomTradeClient
     private
 
     def default_order
-      BloomTradeClient::Order.new(body)
+      BloomTradeClient::Order.new(parsed_body)
     end
 
   end

--- a/app/responses/bloom_trade_client/get_quote_response.rb
+++ b/app/responses/bloom_trade_client/get_quote_response.rb
@@ -48,7 +48,7 @@ module BloomTradeClient
 
     PARAMS.each do |method_name|
       define_method :"default_#{method_name}" do
-        body[method_name]
+        parsed_body[method_name]
       end
     end
 

--- a/spec/acceptance/update_quote_spec.rb
+++ b/spec/acceptance/update_quote_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Update Quote" do
       )
 
       expect(response).not_to be_success
-      json = JSON.parse(response.raw_response.body)
+      json = response.parsed_body
 
       expect(json["errors"]["destination_memo"])
         .to include "is already assigned"

--- a/spec/lib/bloom_trade_client/responses/base_response_spec.rb
+++ b/spec/lib/bloom_trade_client/responses/base_response_spec.rb
@@ -17,5 +17,15 @@ module BloomTradeClient
       end
     end
 
+    describe "#parsed_body" do
+      let(:raw_response) { Typhoeus::Response.new(body: {hi: "there"}.to_json) }
+      let(:response) { described_class.new(raw_response: raw_response) }
+
+      it "is the raw_response's body, parsed" do
+        expect(response.parsed_body["hi"]).to eq "there"
+        expect(response.parsed_body[:hi]).to eq "there"
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Developers should not have to reach out all the way to the raw response just to get the raw body.