### PR TITLE
feat: support for rails `5.x` by loosening the required version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.3.0] - 2022-08-23
 ### Added
 - Support for rails `5.x` by loosening the required version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Support for rails `5.x` by loosening the required version
+
 ## [4.2.0] - 2021-01-13
 ### Added
 - Support for light-service `<= 0.15.0`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bloom_trade_client-rails (4.2.0)
+    bloom_trade_client-rails (4.3.0)
       addressable (~> 2.5)
       api_client_base (~> 1.0)
       light-service (>= 0.11.0, <= 0.15.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       light-service (>= 0.11.0, <= 0.15.0)
       loofah (>= 2.2.3)
       message_bus_client_worker (>= 1.0)
-      rails (~> 6.0)
+      rails (>= 5.0, < 7)
       sidekiq (>= 5.0)
       typhoeus (~> 1.3)
       virtus (~> 1.0)
@@ -318,4 +318,4 @@ RUBY VERSION
    ruby 2.7.3p183
 
 BUNDLED WITH
-   2.2.24
+   2.3.14

--- a/bloom_trade_client.gemspec
+++ b/bloom_trade_client.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency "light-service", [">= 0.11.0", "<= 0.15.0"]
   s.add_dependency "loofah", ">= 2.2.3"
   s.add_dependency "message_bus_client_worker", ">= 1.0"
-  s.add_dependency "rails", "~> 6.0"
+  s.add_dependency "rails", [">= 5.0", "< 7"]
   s.add_dependency "sidekiq", ">= 5.0"
   s.add_dependency "typhoeus", "~> 1.3"
   s.add_dependency "virtus", "~> 1.0"

--- a/lib/bloom_trade_client/version.rb
+++ b/lib/bloom_trade_client/version.rb
@@ -1,3 +1,3 @@
 module BloomTradeClient
-  VERSION = "4.2.0".freeze
+  VERSION = "4.3.0".freeze
 end


### PR DESCRIPTION
This used to be supported but was prematurely upgraded