### PR TITLE
fix: (Attempt to fix) `wrong number of arguments (given 1, expected 0)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- (Attempt to fix) `wrong number of arguments (given 1, expected 0)`
+
 ## [4.3.1] - 2022-08-25
 ### Fixed
 - no implicit conversion of Hash into String with MessageBusClientWorker 2.1.1+


### PR DESCRIPTION
`subscriptions` is used as a method name and a local variable. I think
this was causing the argument error in staging.

This should fix it, but if not, at least it makes it makes a difference
between the method and the local variable